### PR TITLE
Remove redundant gender indicators

### DIFF
--- a/data/alternate_forms_gen6.js
+++ b/data/alternate_forms_gen6.js
@@ -136,6 +136,8 @@ formes[670] = ['Red', 'Yellow', 'Orange', 'Blue', 'White', 'Eternal'];
 
 formes[676] = [null, 'Heart', 'Star', 'Diamond', 'Debutante', 'Matron', 'Dandy', 'La Reine', 'Kabuki', 'Pharaoh'];
 
+formes[678] = [null, null];
+
 formes[681] = ['Shield', 'Blade'];
 
 [710, 711].forEach(i => {

--- a/data/alternate_forms_gen7.js
+++ b/data/alternate_forms_gen7.js
@@ -130,7 +130,7 @@ formes[658] = [null, null, 'Ash'];
 
 formes[670] = ['Red', 'Yellow', 'Orange', 'Blue', 'White', 'Eternal'];
 formes[676] = [null, 'Heart', 'Star', 'Diamond', 'Debutante', 'Matron', 'Dandy', 'La Reine', 'Kabuki', 'Pharaoh'];
-formes[678] = ['Male', 'Female'];
+formes[678] = [null, null];
 formes[681] = ['Shield', 'Blade'];
 
 [710, 711].forEach(i => {


### PR DESCRIPTION
This pull request removes redundant gender indicators for ~~Nidoran and~~ Meowstic.

Before:

* [Nidoran](http://i.imgur.com/6jtre6t.png)
* [Meowstic](https://i.imgur.com/VWKCZ9D.png)

After:

* ~~[Nidoran](http://i.imgur.com/BxwQGMx.png)~~
* [Meowstic](http://i.imgur.com/IJCK0w9.png)

Edit: Removed changes to Nidoran as per @not-an-aardvark's request in the comments. This will be taken care of on the Porybox end instead.